### PR TITLE
change installation tasks from yum to package

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install packages
-  yum:
+  package:
     name: '{{ item.name }}'
     state: '{{ item.state }}'
   with_items: '{{ fail2ban_packages }}'


### PR DESCRIPTION
* python2 yum module is needed
* yum only for fedora user


 `TASK [KainosSoftwareLtd.fail2ban : Install packages] *****************************************************************************************************************************************
failed: [woodstock] (item={u'state': u'installed', u'name': u'fail2ban'}) => {"changed": false, "item": {"name": "fail2ban", "state": "installed"}, "msg": "python2 yum module is needed for this  module"}
`